### PR TITLE
BoltDB repo archived - author recommends BBolt

### DIFF
--- a/boltsec.go
+++ b/boltsec.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"github.com/boltdb/bolt"
+	bolt "go.etcd.io/bbolt"
 	"log"
 	"os"
 	"path/filepath"

--- a/example/article.go
+++ b/example/article.go
@@ -25,7 +25,7 @@ SOFTWARE.*/
 package example
 
 import (
-	"boltsec"
+	"github.com/linkthings/boltsec"
 	"encoding/json"
 	"errors"
 	"fmt"


### PR DESCRIPTION
Ben Johnson's BoltDB github page has been archived

![image](https://user-images.githubusercontent.com/66655567/92349895-9416b980-f101-11ea-9348-896e3bc0da8b.png)

He wrote:
> If you are interested in using a more featureful version of Bolt, I suggest that you look at the CoreOS fork called bbolt.

I've just made a small patch so that people wanting to use this library can benefit from the most current features and bugfixes added via BBolt.